### PR TITLE
domains: fix order cancellation

### DIFF
--- a/src/domains/Order/index.js
+++ b/src/domains/Order/index.js
@@ -211,7 +211,7 @@ class Order {
       .count({
         where: {
           originId: id,
-          originType: 'orderProduct',
+          originType: 'order',
           available: false,
         },
       })
@@ -224,7 +224,7 @@ class Order {
       .destroy({
         where: {
           originId: id,
-          originType: 'orderProduct',
+          originType: 'order',
         },
         force: true,
         transaction,


### PR DESCRIPTION
Individual products were not being removed after order cancellation.
Fix it by changing the origin type